### PR TITLE
hotfix/overlapInSignInEmailScreen

### DIFF
--- a/app.json
+++ b/app.json
@@ -24,7 +24,8 @@
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#FFFFFF"
-      }
+      },
+      "softwareKeyboardLayoutMode": "pan"
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Frontend App
 
+## Version 0.7.1
+- Fixed:
+  - Overlap when the keyboard is open in the SignInEmail screen. 
+
 ## Version 0.7.0
 
 - Implemented:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "main": "./src/index.tsx",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",


### PR DESCRIPTION
Se debe probar lo siguiente:

- Que cuando se abra el teclado en la pantalla SignInEmail no pushee la UI hacia arriba, sino que haga un overlap.

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>